### PR TITLE
Deregistering during init failure by calling misc_deregister

### DIFF
--- a/ch1/miscdrv_rdwr/miscdrv_rdwr.c
+++ b/ch1/miscdrv_rdwr/miscdrv_rdwr.c
@@ -295,8 +295,10 @@ static int __init miscdrv_rdwr_init(void)
 	 * is unloaded from memory
 	 */
 	ctx = devm_kzalloc(dev, sizeof(struct drv_ctx), GFP_KERNEL);
-	if (unlikely(!ctx))
+	if (unlikely(!ctx)) {
+		misc_deregister(&llkd_miscdev);
 		return -ENOMEM;
+	}
 
 	ctx->dev = dev;
 	/* Initialize the "secret" value :-) */


### PR DESCRIPTION
Log:
pradipta@pradipta-VM: ~/Documents/Courses/kaiwansirldd/ws/Linux-Kernel-Programming-Part-2/ch1/miscdrv_rdwr/ [pradipta_lkp2]  

$: ./rdwr_test_secret w /dev/llkd_miscdrv_rdwr "Wonderful" 

Device file /dev/llkd_miscdrv_rdwr opened (in write-only mode): fd=3 

./rdwr_test_secret: wrote 10 bytes to /dev/llkd_miscdrv_rdwr 

pradipta@pradipta-VM: ~/Documents/Courses/kaiwansirldd/ws/Linux-Kernel-Programming-Part-2/ch1/miscdrv_rdwr/ [pradipta_lkp2]  

$: ./rdwr_test_secret r /dev/llkd_miscdrv_rdwr 

Device file /dev/llkd_miscdrv_rdwr opened (in read-only mode): fd=3 

./rdwr_test_secret: read 9 bytes from /dev/llkd_miscdrv_rdwr 

The 'secret' is: 

"Wonderful" 